### PR TITLE
append timezone offset to date so it parses in correct TZ

### DIFF
--- a/javascript/jquery.daterangepicker.js
+++ b/javascript/jquery.daterangepicker.js
@@ -631,6 +631,12 @@ $.fn.daterangepicker = function(_options) {
     }
   }
 
+  // make the date be parsed as midnight in the local TZ so it doesn't increment/decrement 
+  var tzo=(new Date()).getTimezoneOffset();
+  var tz_sign = tzo>0 ? '-' : '+';                         // the reverse of the sign of tzo
+  var tzo_hours = ('0' + (Math.floor(tzo/60).toString())).substr(-2,2);
+  var tzo_minutes = ('0' + ((tzo%60).toString())).substr(-2,2);
+  var tz_string = tz_sign+tzo_hours+':'+tzo_minutes;
 
   $.each(["from", "to"], function(idx, type) {
     if ($(daterange.fields[type]).val() === "") {
@@ -642,7 +648,8 @@ $.fn.daterangepicker = function(_options) {
       }
     }
     else {
-      daterange[type] = new Date($(daterange.fields[type]).val());
+      var dt_in = $(daterange.fields[type]).val();
+      daterange[type] = new Date(dt_in + ' 00:00:00 ' + tz_string);
     }
   });
 


### PR DESCRIPTION
Sugi-san:

I ran into an issue where the picker would decrement the date every time it popped up.  Traced this to the fact that the Javascript "Date" parser was treating the date as midnight GMT, but here in GMT-8 land, that would print out as if it were 4 PM the previous day.  Added the code you see to append a 00:00 time part and a timezone offset string based on the current locale.  

Hope this change is acceptable for inclusion.

Eric Weaver
Boopsie, Inc.
Sunnyvale, California
